### PR TITLE
Assertions to clarify precise merging behavior.

### DIFF
--- a/reader/configreader.go
+++ b/reader/configreader.go
@@ -1,12 +1,11 @@
 package reader
 
 import (
-	"io"
-	"path/filepath"
-	// "github.com/spf13/cast"
 	"bytes"
 	"encoding/json"
+	"io"
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jacobstr/confer/errors"
@@ -29,20 +28,6 @@ type ConfigReader struct {
 
 // Retuns the configuration data into a generic object for for us.
 func (cr *ConfigReader) Export() (interface{}, error) {
-	return cr.ExportAs(struct{}{})
-}
-
-// Provide a struct to marshall this config reader's data into.  This allows some
-// usage by those who might want to take advantage of the json decoders custom
-// tags e.g.
-//
-//	struct Database {
-//		Host string `json:"host"`
-//		Port int		`json:"port"`
-//	}
-//
-// Though we tend to convert to stringmaps anyway.
-func (cr *ConfigReader) ExportAs(template struct{}) (interface{}, error) {
 	var config interface{}
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(cr.reader)
@@ -69,7 +54,7 @@ func (cr *ConfigReader) ExportAs(template struct{}) (interface{}, error) {
 	return config, nil
 }
 
-func Readfile(path string) (interface{}, error) {
+func ReadFile(path string) (interface{}, error) {
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
 		jww.DEBUG.Println("Error reading config file:", err)
@@ -82,7 +67,7 @@ func Readfile(path string) (interface{}, error) {
 	return cr.Export()
 }
 
-func Readbytes(data []byte, format string) (interface{}, error) {
+func ReadBytes(data []byte, format string) (interface{}, error) {
 	cr := ConfigReader{
 		Format: format,
 		reader: bytes.NewReader(data),

--- a/test/fixtures/merging.yaml
+++ b/test/fixtures/merging.yaml
@@ -1,0 +1,18 @@
+---
+# Used to exercise attribute merging when we transition
+# from a number -> stringmap and vice versa.
+mapusers:
+  bob: /home/bob
+  jim: /home/jim
+
+moreusers:
+  andy: /home/andy
+
+intusers: 5
+
+arrayusers:
+  - bob
+  - jim
+
+morearrayusers:
+  - andy

--- a/util.go
+++ b/util.go
@@ -1,12 +1,13 @@
 package confer
 
-import(
+import (
 	"fmt"
 	"os"
-	jww "github.com/spf13/jwalterweatherman"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	jww "github.com/spf13/jwalterweatherman"
 )
 
 // Check if File / Directory Exists


### PR DESCRIPTION
Also added some additional documentation providing environment specific file
overrides.

Major change, to get some of the naming cleaned up;
  confer.ConfigManager -> confer.Config
  confer.NewConfiguration -> confer.Config

A few potentially breaking changes to unpublicized but public packages:
  reader.Readfile -> reader.ReadFile
  reader.Readbytes -> reader.ReadBytes
  reader.ExportAs : removed, it was broken and I might think about how to support
    marshalling into structs, if at all.
