### PR TITLE
Prune ancestors from the AllSettings() result.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,10 @@ Features
     config.GetInt('app.database.port')
   ```
 3. Binding of environment variables to configuration data.
-    
+
     `APP_DATABASE_PORT=3456 go run app.go`
 
-4. Three precedence tiers:
-        1. CLI Flags
-        2. Environment vars.
-        3. Set / SetDefault / Files.
-
+4. User-defined helper methods.
 
 ## Usage
 
@@ -146,21 +142,16 @@ config.ReadPaths("application.yaml")
 config.AutomaticEnv()
 ```
 
-Your final configuration will incorporate these environment variables, if set:
-
+You'll have the following environment variables exposed for configuration:
 ```
-APP
 APP_LOG
-APP_DATABASE
 APP_DATABASE_HOST
 ```
 
-Practically, you'd only only want to set the "leaf nodes" this way - `APP_DATABASE_HOST` and `APP_LOG`.
-Unfortunately, trying something clever like `APP='{ "log": "debug" }'` won't currently work - you'll
-simply clobber `app` with a string.
-
 ##### Selective Binding
-If this automatic binding is bizarre, you can selectively bind environment variables to configuration keys using:
+If this automatic binding is bizarre, you can selectively bind environment variables
+with ``BindEnv()`.
+
 ```go
 config.BindEnv("APP_LOG", "app.log")
 ```

--- a/maps/util.go
+++ b/maps/util.go
@@ -34,11 +34,11 @@ func traverse(data map[string]interface{}, path string, depth int, cb Traverser)
 	}
 }
 
-// Recursively collects all keys into a flattened map of materialized paths.
-func CollectKeys(data map[string]interface{}, path string, max_depth int) map[string]struct{} {
-	m := map[string]struct{}{}
+// Recursively collects all keys into a flattened slice of materialized paths.
+func CollectKeys(data map[string]interface{}, path string, max_depth int) []string {
+	m := []string{}
 	Traverse(data, func(key string, val interface{}, depth int) bool {
-		m[key] = struct{}{}
+		m = append(m, key)
 		return max_depth == -1 || depth <= max_depth
 	})
 	return m

--- a/source/env.go
+++ b/source/env.go
@@ -48,6 +48,14 @@ func (self *EnvSource) Bind(input ...string) (err error) {
 	return nil
 }
 
+func (self *EnvSource) AllKeys() []string {
+	a := []string{}
+	for x, _ := range self.index {
+		a = append(a, strings.ToLower(x))
+	}
+	return a
+}
+
 // Gets an environment variable.
 func (self *EnvSource) Get(key string) (val interface{}, exists bool) {
 	envkey, exists := self.index[key]


### PR DESCRIPTION
They end up making the output noisy and less useful.
