### PR TITLE
fixed pflags binding bug

### DIFF
--- a/source/pflags.go
+++ b/source/pflags.go
@@ -1,8 +1,6 @@
 package source
 
 import (
-	"strings"
-
 	"github.com/spf13/pflag"
 )
 
@@ -18,7 +16,7 @@ func NewPFlagSource() *PFlagSource {
 }
 
 func (self *PFlagSource) Get(key string) (interface{}, bool) {
-	val, exists := self.data[strings.ToLower(key)]
+	val, exists := self.data[key]
 	if exists == false {
 		return nil, false
 	}


### PR DESCRIPTION
Set() and Get() weren't compatible.  Removed spurious(?) strings.ToLower(key).

Doesn't seem like it would break any existing behavior.